### PR TITLE
Remove no-empty-blocks rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ module.exports = {
   "rules": {
     /* Best Practise Rules */
     "max-states-count": ["warn", 15],
-    "no-empty-blocks": "warn",
     "no-unused-vars": "error",
     "payable-fallback": "warn",
     "reason-string": ["error", {"maxLength": 250}],


### PR DESCRIPTION
This pull request removes `no-empty-blocks` rule from the default configuration of `solhint` for the `Keep` project.